### PR TITLE
feat: add yapf python format

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [ ] [swiftformat](https://github.com/nicklockwood/SwiftFormat)
 - [ ] [swift-format](https://github.com/apple/swift-format)
 - [x] [sql-formatter](https://github.com/sql-formatter-org/sql-formatter)
+- [x] [yapf](https://github.com/google/yapf)
 
 ## Linters
 

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -139,4 +139,10 @@ M['sql-formatter'] = {
   stdin = true,
 }
 
+M.yapf = {
+  cmd = 'yapf',
+  args = { '--quiet' },
+  stdin = true,
+}
+
 return M

--- a/test/formatter/yapf_spec.lua
+++ b/test/formatter/yapf_spec.lua
@@ -1,0 +1,26 @@
+describe('yapf', function()
+  it('can format', function()
+    local ft = require('guard.filetype')
+    ft('python'):fmt('yapf')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('python', {
+      [[def foo(n):]],
+      [[    if n in         (1,2,3):]],
+      [[        return n+1]],
+      [[a, b = 1,    2]],
+      [[b, a =     a, b]],
+      [[print(  f"The factorial of {a} is: {foo(a)}")]],
+    })
+    assert.are.same({
+      [[def foo(n):]],
+      [[    if n in (1, 2, 3):]],
+      [[        return n + 1]],
+      [[]],
+      [[]],
+      [[a, b = 1, 2]],
+      [[b, a = a, b]],
+      [[print(f"The factorial of {a} is: {foo(a)}")]],
+    }, formatted)
+  end)
+end)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -8,7 +8,7 @@ sudo apt-get install -qqq \
     clang-format clang-tidy fish elixir &
 luarocks install luacheck &
 go install github.com/segmentio/golines@latest &
-pip -qqq install autopep8 black djhtml isort pylint &
+pip -qqq install autopep8 black djhtml isort pylint yapf &
 npm install -g --silent \
     prettier @fsouza/prettierd sql-formatter shellcheck shfmt &
 gem install -q rubocop &


### PR DESCRIPTION
Test passed with my guard.nvim fork with yapf in it:
`ok 10 - yapf can format`