### PR TITLE
feat: add autopep8 for python format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Formatters
 
 - `lsp` using `vim.lsp.buf.format`
+- [x] [autopep8](https://github.com/hhatto/autopep8)
 - [x] [black](https://github.com/psf/black)
 - [x] [cbfmt](https://github.com/lukas-reineke/cbfmt)
 - [x] [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html)

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -6,6 +6,12 @@ M.lsp = {
   end,
 }
 
+M.autopep8 = {
+  cmd = 'autopep8',
+  args = { '-' },
+  stdin = true,
+}
+
 M.black = {
   cmd = 'black',
   args = { '--quiet', '-' },

--- a/test/formatter/autopep8_spec.lua
+++ b/test/formatter/autopep8_spec.lua
@@ -1,0 +1,26 @@
+describe('autopep8', function()
+  it('can format', function()
+    local ft = require('guard.filetype')
+    ft('python'):fmt('autopep8')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('python', {
+      [[def foo(n):]],
+      [[    if n in         (1,2,3):]],
+      [[        return n+1]],
+      [[a, b = 1,    2]],
+      [[b, a =     a, b]],
+      [[print(  f"The factorial of {a} is: {foo(a)}")]],
+    })
+    assert.are.same({
+      [[def foo(n):]],
+      [[    if n in (1, 2, 3):]],
+      [[        return n+1]],
+      [[]],
+      [[]],
+      [[a, b = 1,    2]],
+      [[b, a = a, b]],
+      [[print(f"The factorial of {a} is: {foo(a)}")]],
+    }, formatted)
+  end)
+end)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -8,7 +8,7 @@ sudo apt-get install -qqq \
     clang-format clang-tidy fish elixir &
 luarocks install luacheck &
 go install github.com/segmentio/golines@latest &
-pip -qqq install black djhtml isort pylint &
+pip -qqq install autopep8 black djhtml isort pylint &
 npm install -g --silent \
     prettier @fsouza/prettierd sql-formatter shellcheck shfmt &
 gem install -q rubocop &


### PR DESCRIPTION
Test passed with my guard.nvim fork with autopep8 in it:
`ok 1 - autopep8 can format`