### PR TITLE
chore: adjust golines max-len to 180

### DIFF
--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -61,7 +61,7 @@ M.gofmt = {
 
 M.golines = {
   cmd = 'golines',
-  args = { '--max-len=80' },
+  args = { '--max-len=180' },
   stdin = true,
 }
 


### PR DESCRIPTION
Default `--max-len` should be `180` instead of `80`, I guess there is a typo there.