### PR TITLE
feat: register dotnet-csharpier formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [x] [black](https://github.com/psf/black)
 - [ ] [cbfmt](https://github.com/lukas-reineke/cbfmt)
 - [x] [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html)
+- [x] [csharpier](https://csharpier.com/)
 - [ ] [djhtml](https://github.com/rtts/djhtml)
 - [ ] [dprint](https://dprint.dev/)
 - [ ] [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html)

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -29,6 +29,12 @@ M['clang-format'] = {
   stdin = true,
 }
 
+M.csharpier = {
+  cmd = 'dotnet-csharpier',
+  args = { '--write-stdout' },
+  stdin = true,
+}
+
 M.djhtml = {
   cmd = 'djhtml',
   args = { '-' },


### PR DESCRIPTION
Formatter for `csharp`, reference from [null-ls implementation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/csharpier.lua) which I'm also using personally while working with Unity.