### PR TITLE
feat: register zigfmt formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [ ] [swift-format](https://github.com/apple/swift-format)
 - [x] [sql-formatter](https://github.com/sql-formatter-org/sql-formatter)
 - [x] [yapf](https://github.com/google/yapf)
+- [x] [zigfmt](https://github.com/ziglang/zig)
 
 ## Linters
 

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -151,4 +151,10 @@ M.yapf = {
   stdin = true,
 }
 
+M.zigfmt = {
+  cmd = 'zigfmt',
+  args = { 'fmt', '--stdin' },
+  stdin = true,
+}
+
 return M


### PR DESCRIPTION
Zig's `zigfmt`, reference from [null-ls implementation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/zigfmt.lua), which I'm using personally.