### PR TITLE
feat: register eslint_d formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [x] [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html)
 - [ ] [djhtml](https://github.com/rtts/djhtml)
 - [ ] [dprint](https://dprint.dev/)
+- [x] [eslint_d](https://github.com/mantoni/eslint_d.js)
 - [ ] [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html)
 - [ ] [fnlfmt](https://git.sr.ht/~technomancy/fnlfmt)
 - [ ] [gofmt](https://pkg.go.dev/cmd/gofmt)

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -43,6 +43,13 @@ M.dprint = {
   find = { 'dprint.json', 'dprint.jsonc', '.dprint.json', '.dprint.jsonc' },
 }
 
+M.eslint_d = {
+  cmd = 'eslint_d',
+  args = { '--fix-to-stdout', '--stdin', '--stdin-filename' },
+  fname = true,
+  stdin = true,
+}
+
 M.fish_indent = {
   cmd = 'fish_indent',
   stdin = true,


### PR DESCRIPTION
Since we already have `eslint_d` linter, also register formatter for it. This is much faster than `eslint`, must have.
Reference from this [null-ls implementation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/eslint_d.lua).