### PR TITLE
feat: add taplo formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [x] [prettier](https://github.com/prettier/prettier)
 - [ ] [rubocop](https://github.com/rubocop/rubocop)
 - [x] [rustfmt](https://github.com/rust-lang/rustfmt)
+- [x] [taplo](https://github.com/tamasfe/taplo)
 - [ ] [shfmt](https://github.com/mvdan/sh)
 - [x] [stylua](https://github.com/JohnnyMorganz/StyLua)
 - [ ] [swiftformat](https://github.com/nicklockwood/SwiftFormat)
@@ -36,7 +37,6 @@
 - [x] [yapf](https://github.com/google/yapf)
 - [x] [ruff](https://github.com/astral-sh/ruff) as `ruff format`
 - [x] [ruff_fix](https://github.com/astral-sh/ruff) as `ruff --fix`
-
 
 ## Linters
 

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -132,6 +132,12 @@ M.rustfmt = {
   stdin = true,
 }
 
+M.taplo = {
+  cmd = 'taplo',
+  args = { 'format', '-' },
+  stdin = true,
+}
+
 M.shfmt = {
   cmd = 'shfmt',
   stdin = true,

--- a/test/formatter/taplo_spec.lua
+++ b/test/formatter/taplo_spec.lua
@@ -1,0 +1,24 @@
+describe('taplo', function()
+  it('can format', function()
+    local ft = require('guard.filetype')
+    ft('toml'):fmt('taplo')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('toml', {
+      [[        [dependencies]        ]],
+      [[           async-process = "^1.7"]],
+      [[strum = {       version = "^0.25",   features = ["derive"]       } ]],
+      [[anyhow     = "1" ]],
+      [[tracing-error =     "0.2" ]],
+      [[]],
+      [[]]
+    })
+    assert.are.same({
+      "[dependencies]",
+      [[async-process = "^1.7"]],
+      [[strum = { version = "^0.25", features = ["derive"] }]],
+      [[anyhow = "1"]],
+      [[tracing-error = "0.2"]],
+    }, formatted)
+  end)
+end)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -10,7 +10,7 @@ luarocks install luacheck &
 go install github.com/segmentio/golines@latest &
 pip -qqq install autopep8 black djhtml flake8 isort pylint yapf codespell ruff &
 npm install -g --silent \
-    prettier @fsouza/prettierd sql-formatter shellcheck shfmt &
+    prettier @fsouza/prettierd sql-formatter shellcheck shfmt @taplo/cli &
 gem install -q rubocop &
 # Block, homebrew takes the longest time
 brew install \


### PR DESCRIPTION
Taplo's formatter for .toml files. I got the config from [null-ls implementation](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/taplo.lua)