### PR TITLE
`rustfmt_nightly` formatter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,16 @@ jobs:
           luaVersion: "luajit-2.1.0-beta3"
       - uses: leafo/gh-actions-luarocks@v4
       - uses: actions/setup-python@v4
-      - uses: actions-rs/toolchain@v1
+      - name: install stable Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          default: true
+          components: rustfmt, cargo
+      - name: install nightly Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
           components: rustfmt, cargo
       - uses: actions/setup-node@v3
         with:

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Crate"

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -156,6 +156,15 @@ M.rustfmt = {
   stdin = true,
 }
 
+-- Use the nightly version of `rustfmt` even in projects based on the stable toolchain
+-- The nightly version allows using more settings e.g. `wrap_comments` or `imports_granularity`
+-- Details: https://rust-lang.github.io/rustfmt/
+M.rustfmt_nightly = {
+  cmd = "rustup",
+  args = { "run", "nightly", "rustfmt", "--edition", "2021", "--emit", "stdout" },
+  stdin = true,
+}
+
 M.taplo = {
   cmd = 'taplo',
   args = { 'format', '-' },

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -160,8 +160,8 @@ M.rustfmt = {
 -- The nightly version allows using more settings e.g. `wrap_comments` or `imports_granularity`
 -- Details: https://rust-lang.github.io/rustfmt/
 M.rustfmt_nightly = {
-  cmd = "rustup",
-  args = { "run", "nightly", "rustfmt", "--edition", "2021", "--emit", "stdout" },
+  cmd = 'rustup',
+  args = { 'run', 'nightly', 'rustfmt', '--edition', '2021', '--emit', 'stdout' },
   stdin = true,
 }
 

--- a/test/formatter/rustfmt_nightly_spec.lua
+++ b/test/formatter/rustfmt_nightly_spec.lua
@@ -1,7 +1,7 @@
-describe('rustfmt', function()
+describe('rustfmt_nightly', function()
   it('can format', function()
     local ft = require('guard.filetype')
-    ft('rust'):fmt('rustfmt')
+    ft('rust'):fmt('rustfmt_nightly')
     require('guard').setup()
 
     local formatted = require('test.formatter.helper').test_with('rust', {
@@ -12,7 +12,7 @@ describe('rustfmt', function()
       [[}]],
     })
     assert.are.same({
-      [[use std::{collections::HashMap, collections::HashSet};]],
+      [[use std::collections::{HashMap, HashSet};]],
       [[fn main() {]],
       [[    let var: usize = 1;]],
       [[    println!("{var}");]],


### PR DESCRIPTION
It's common practice to use nightly rustfmt even in projects based on the stable toolchain, as there's more settings available.

I'm not sure if I should add the installation of the nightly toolchain to the `setup.sh` as there's no Rust setup section.

### Checklist (adding a new tool):

- [x] The tool was added to the README (already there)
- [x] I have written corresponding tests for the tools I added