### PR TITLE
feat: add biome as formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - `lsp` using `vim.lsp.buf.format`
 - [x] [autopep8](https://github.com/hhatto/autopep8)
 - [x] [black](https://github.com/psf/black)
+- [x] [biome](https://biomejs.dev)
 - [ ] [cbfmt](https://github.com/lukas-reineke/cbfmt)
 - [x] [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html)
 - [ ] [csharpier](https://csharpier.com/)

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -266,4 +266,11 @@ M.zigfmt = {
   stdin = true,
 }
 
+M.biome = {
+  cmd = 'biome',
+  args = { 'format', '--write' },
+  fname = true,
+  stdin = false,
+}
+
 return M

--- a/test/formatter/biome_spec.lua
+++ b/test/formatter/biome_spec.lua
@@ -1,0 +1,32 @@
+describe('biome', function()
+  it('can format json', function()
+    local ft = require('guard.filetype')
+    ft('json'):fmt('biome')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('json', {
+      [[{"name":   "dove" , "age":10 ]],
+      [[,"gender":   "male"}]],
+    })
+    assert.are.same({
+      [[{ "name": "dove", "age": 10, "gender": "male" }]],
+    }, formatted)
+  end)
+
+  it('can format javascript', function()
+    local ft = require('guard.filetype')
+    ft('js'):fmt('biome')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('js', {
+      [[            const randomNumber = Math.floor(]],
+      [[      Math.random() *           10]],
+      [[      ) + 1]],
+      [[alert(randomNumber)]],
+    })
+    assert.are.same({
+      [[const randomNumber = Math.floor(Math.random() * 10) + 1;]],
+      [[alert(randomNumber);]],
+    }, formatted)
+  end)
+end)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -7,7 +7,7 @@ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 luarocks install luacheck &
 pip -qqq install autopep8 black djhtml docformatter flake8 isort pylint yapf codespell ruff sqlfluff clang-tidy mypy &
 npm install -g --silent \
-    prettier @fsouza/prettierd sql-formatter shellcheck shfmt @taplo/cli &
+    prettier @fsouza/prettierd sql-formatter shellcheck shfmt @taplo/cli @biomejs/biome &
 brew install \
     hlint ormolu clang-format golines gofumpt detekt &
 


### PR DESCRIPTION
add [biome](https://biomejs.dev) to format `json` and `javascript` things.

`biome` is a replacement for `prettier` with better performance.

I'm not using `npx` to run command since `npx` noticeably slow down the startup of `biome`.

`biome` refuse to format file with extension `javascript`, thus  I'm using `js` instead of `javascript` in the test.

## Estimated time consumption for different commands:

`time npx prettier --stdin-filepath demo.json`
Executed in  457.11 millis    fish           external
   usr time  432.23 millis    0.00 micros  432.23 millis
   sys time  199.27 millis  703.00 micros  198.57 millis

`time npx @biomejs/biome format --write demo.json`
Executed in    1.15 secs      fish           external
   usr time  635.26 millis    0.40 millis  634.87 millis
   sys time  340.36 millis    1.12 millis  339.24 millis

`time prettier --stdin-filepath demo.json`
Executed in  145.69 millis    fish           external
   usr time  120.74 millis  363.00 micros  120.38 millis
   sys time   89.82 millis  113.00 micros   89.71 millis

`time biome format --write demo.json`
Executed in   57.95 millis    fish           external
   usr time   30.06 millis  415.00 micros   29.64 millis
   sys time   48.54 millis  763.00 micros   47.78 millis

