### PR TITLE
feat: swiftformat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - [x] [taplo](https://github.com/tamasfe/taplo)
 - [ ] [shfmt](https://github.com/mvdan/sh)
 - [x] [stylua](https://github.com/JohnnyMorganz/StyLua)
-- [ ] [swiftformat](https://github.com/nicklockwood/SwiftFormat)
+- [x] [swiftformat](https://github.com/nicklockwood/SwiftFormat)
 - [ ] [swift-format](https://github.com/apple/swift-format)
 - [ ] [sqlfluff](https://github.com/sqlfluff/sqlfluff) as `sqlfluff format`
 - [x] [sqlfluff_fix](https://github.com/sqlfluff/sqlfluff) as `sqlfluff fix`

--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -216,7 +216,9 @@ M.stylua = {
 
 M.swiftformat = {
   cmd = 'swiftformat',
+  args = { '--stdinpath' },
   stdin = true,
+  fname = true,
 }
 
 M['swift-format'] = {

--- a/test/formatter/swiftformat.lua
+++ b/test/formatter/swiftformat.lua
@@ -1,0 +1,18 @@
+describe('swiftformat', function()
+  it('can format', function()
+    local ft = require('guard.filetype')
+    ft('swift'):fmt('swiftformat')
+    require('guard').setup()
+
+    local formatted = require('test.formatter.helper').test_with('swift', {
+      [[func myFunc()        { ]],
+      [[print("hello")  ]],
+      [[  }]],
+    })
+    assert.are.same({
+      [[func myFunc() {]],
+      [[    print("hello")]],
+      [[}]],
+    }, formatted)
+  end)
+end)

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -9,7 +9,7 @@ pip -qqq install autopep8 black djhtml docformatter flake8 isort pylint yapf cod
 npm install -g --silent \
     prettier @fsouza/prettierd sql-formatter shellcheck shfmt @taplo/cli @biomejs/biome &
 brew install \
-    hlint ormolu clang-format golines gofumpt detekt &
+    hlint ormolu clang-format golines gofumpt detekt swiftformat &
 
 # Install standalone binary packages
 bin="$HOME/.local/bin"


### PR DESCRIPTION
### Checklist (adding a new tool):

- [ ] If it's a linter it was exported in linter/init.lua
- [x] The tool was added to the README
- [x] I do not wish to write a test, but I can confirm that _it works on my machine_ _*OR*_ I have written corresponding tests for the tools I added. (don't worry if you didn't write a test, it's just nice to see the green check mark)

Needed to use --stdinpath to fix this [issue](https://github.com/nicklockwood/SwiftFormat/issues/512), where swiftformat was not respecting the config file.