### PR TITLE
fix: biome cannot do format on current version of guard

### DIFF
--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -276,9 +276,9 @@ M.zigfmt = {
 
 M.biome = {
   cmd = 'biome',
-  args = { 'format', '--write' },
+  args = { 'format', '--stdin-file-path' },
   fname = true,
-  stdin = false,
+  stdin = true,
 }
 
 return M


### PR DESCRIPTION
I realized that biome does support stdin. Thus it can support range format.