### PR TITLE
fix: unsupported usage

### DIFF
--- a/lua/guard-collection/linter/shellcheck.lua
+++ b/lua/guard-collection/linter/shellcheck.lua
@@ -1,7 +1,6 @@
 return {
   cmd = 'shellcheck',
   args = { '--format', 'json1', '--external-sources' },
-  stdin = true,
   parse = require('guard.lint').from_json({
     get_diagnostics = function(...)
       return vim.json.decode(...).comments


### PR DESCRIPTION
### Checklist (adding a new tool):

- [x] If it's a linter it was exported in linter/init.lua
- [x] The tool was added to the README
- [x] I do not wish to write a test, but I can confirm that _it works on my machine_ _*OR*_ I have written corresponding tests for the tools I added. (don't worry if you didn't write a test, it's just nice to see the green check mark)

stdin is not supported

<img width="967" alt="image" src="https://github.com/user-attachments/assets/831131b0-d0cf-4557-b3fd-d96ac1951e58" />
