### PR TITLE
feat(linter): add typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [ ] [shellcheck](https://github.com/koalaman/shellcheck)
 - [ ] [stylelint](https://stylelint.io/)
 - [x] [ruff](https://github.com/astral-sh/ruff)
+- [ ] [typos](https://github.com/crate-ci/typos)
 - [ ] [mypy](https://mypy.readthedocs.io/en/stable/index.html)
 - [ ] [mypyc](https://mypyc.readthedocs.io/en/latest/index.html)
 - [ ] [dmypy](https://mypy.readthedocs.io/en/stable/mypy_daemon.html)

--- a/lua/guard-collection/linter/init.lua
+++ b/lua/guard-collection/linter/init.lua
@@ -17,6 +17,7 @@ return {
   shellcheck = require('guard-collection.linter.shellcheck'),
   stylelint = require('guard-collection.linter.stylelint'),
   ruff = require('guard-collection.linter.ruff'),
+  typos = require('guard-collection.linter.typos'),
   mypy = require('guard-collection.linter.mypy').mypy,
   mypyc = require('guard-collection.linter.mypy').mypyc,
   dmypy = require('guard-collection.linter.mypy').dmypy,

--- a/lua/guard-collection/linter/typos.lua
+++ b/lua/guard-collection/linter/typos.lua
@@ -1,0 +1,39 @@
+local lint = require('guard.lint')
+return {
+  cmd = 'typos',
+  stdin = false,
+  fname = true,
+  args = { '--format=json', '--force-exclude' },
+  parse = function(result, bufnr)
+    if result == '' then
+      return {}
+    end
+
+    local diagnostics = {}
+
+    for json in string.gmatch(result, '[%S]+') do
+      local item = vim.json.decode(json)
+
+      if item ~= nil and item.line_num ~= nil then
+        local line_num = item.line_num - 1
+        local corrections = table.concat(item.corrections, ' / ')
+
+        table.insert(
+          diagnostics,
+          lint.diag_fmt(
+            bufnr,
+            line_num,
+            item.byte_offset,
+            string.format('`%s` should be `%s`', item.typo, corrections),
+            vim.diagnostic.severity.WARN,
+            '[typos] ' .. item.type,
+            line_num,
+            item.byte_offset + item.type:len()
+          )
+        )
+      end
+    end
+
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
### Checklist (adding a new tool):

- [x] If it's a linter it was exported in linter/init.lua
- [x] The tool was added to the README
- [x] I do not wish to write a test, but I can confirm that _it works on my machine_ _*OR*_ I have written corresponding tests for the tools I added. (don't worry if you didn't write a test, it's just nice to see the green check mark)
