### PR TITLE
fix(tombi): use `--offline` for formatting

### DIFF
--- a/lua/guard-collection/formatter.lua
+++ b/lua/guard-collection/formatter.lua
@@ -347,7 +347,7 @@ M.goimports = {
 
 M.tombi = {
   cmd = 'tombi',
-  args = { 'format', '-' },
+  args = { 'format', '--offline', '-' },
   stdin = true,
 }
 


### PR DESCRIPTION
`tombi` fetches crates.io every running by default, so formatting should run with `--offline`.