### PR TITLE
feat(linter): add checkmake makefile linter

### DIFF
--- a/lua/guard-collection/linter/checkmake.lua
+++ b/lua/guard-collection/linter/checkmake.lua
@@ -1,0 +1,35 @@
+local lint = require('guard.lint')
+
+return {
+  fn = function(_, fname)
+    local co = assert(coroutine.running())
+    vim.system({
+      'checkmake',
+      '--format={{.FileName}}:{{.LineNumber}}: [{{.Rule}}] {{.Violation}}\n',
+      fname,
+    }, {}, function(result)
+      coroutine.resume(co, result.stdout or '')
+    end)
+    return coroutine.yield()
+  end,
+  parse = function(result, bufnr)
+    local diags = {}
+    for line in result:gmatch('[^\n]+') do
+      local lnum, rule, msg = line:match(':(%d+): %[([^%]]+)%] (.+)$')
+      if lnum then
+        table.insert(
+          diags,
+          lint.diag_fmt(
+            bufnr,
+            tonumber(lnum),
+            0,
+            ('[%s] %s'):format(rule, msg),
+            vim.diagnostic.severity.WARN,
+            'checkmake'
+          )
+        )
+      end
+    end
+    return diags
+  end,
+}

--- a/lua/guard-collection/linter/init.lua
+++ b/lua/guard-collection/linter/init.lua
@@ -1,4 +1,5 @@
 return {
+  checkmake = require('guard-collection.linter.checkmake'),
   ['clang-tidy'] = require('guard-collection.linter.clang-tidy'),
   codespell = require('guard-collection.linter.codespell'),
   detekt = require('guard-collection.linter.detekt'),

--- a/test/linter/checkmake_spec.lua
+++ b/test/linter/checkmake_spec.lua
@@ -1,0 +1,48 @@
+describe('checkmake', function()
+  it('can lint', function()
+    local helper = require('test.linter.helper')
+    local ns = helper.namespace
+    local ft = require('guard.filetype')
+    ft('make'):lint('checkmake')
+
+    local buf, diagnostics = helper.test_with('make', {
+      [[all:]],
+      [[\techo hello]],
+    })
+    assert.are.same({
+      {
+        bufnr = buf,
+        col = 0,
+        end_col = 0,
+        end_lnum = 0,
+        lnum = 0,
+        message = '[minphony] Missing required phony target "all"',
+        namespace = ns,
+        severity = 2,
+        source = 'checkmake',
+      },
+      {
+        bufnr = buf,
+        col = 0,
+        end_col = 0,
+        end_lnum = 0,
+        lnum = 0,
+        message = '[minphony] Missing required phony target "clean"',
+        namespace = ns,
+        severity = 2,
+        source = 'checkmake',
+      },
+      {
+        bufnr = buf,
+        col = 0,
+        end_col = 0,
+        end_lnum = 0,
+        lnum = 0,
+        message = '[minphony] Missing required phony target "test"',
+        namespace = ns,
+        severity = 2,
+        source = 'checkmake',
+      },
+    }, diagnostics)
+  end)
+end)


### PR DESCRIPTION
adds checkmake linter for makefiles.

- custom format template for parsing
- uses custom `fn` to capture stdout